### PR TITLE
_ctest_main introduced and ctest converted to library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LDYNAMIC := -Llib/
 
 LDLIBRPATH := lib/
 
-SHARED_LIB = lib/libctests.so
+SHARED_LIB = lib/libctest.so
 
 #Currently, the supported suites are Basic and Modern.
 MY_SUITES := -DSUITE=Basic
@@ -23,8 +23,8 @@ $(SHARED_LIB): $(OBJECTS)
 	$(CC) $(CFLAGS) -shared -o $@ $^
 
 example:
-	$(CC) $(MY_SUITES) $(CFLAGS) -Wl,-rpath=$(LDLIBRPATH) $(SRC) -o $@ $(LDYNAMIC) -lctests
+	$(CC) $(MY_SUITES) $(CFLAGS) -Wl,-rpath=$(LDLIBRPATH) $(SRC) -o $@ $(LDYNAMIC) -lctest
 
 clean:
 	@echo "Cleaning..."
-	@rm -rfv src/ctest_main.o src/assertions.o example lib/libctests.so
+	@rm -rfv src/ctest_main.o src/assertions.o example lib/libctest.so

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,30 @@
-CFLAGS := -Iinclude
+CFLAGS := -fPIC -Iinclude
 
-example: example.c src/ctest_main.o src/assertions.o
+SRC := example.c
+
+OBJECTS := src/ctest_main.o src/assertions.o
+
+LDYNAMIC := -Llib/
+
+LDLIBRPATH := lib/
+
+SHARED_LIB = lib/libctests.so
+
+#Currently, the supported suites are Basic and Modern.
+MY_SUITES := -DSUITE=Basic
+
+all: $(SHARED_LIB) example
 
 src/ctest_main.o: src/ctest_main.c
 
 src/assertions.o: src/assertions.c
 
+$(SHARED_LIB): $(OBJECTS)
+	$(CC) $(CFLAGS) -shared -o $@ $^
+
+example:
+	$(CC) $(MY_SUITES) $(CFLAGS) -Wl,-rpath=$(LDLIBRPATH) $(SRC) -o $@ $(LDYNAMIC) -lctests
+
 clean:
 	@echo "Cleaning..."
-	@rm -rfv src/ctest_main.o src/assertions.o example
+	@rm -rfv src/ctest_main.o src/assertions.o example lib/libctests.so

--- a/example.c
+++ b/example.c
@@ -7,11 +7,6 @@
 
 #include <stdio.h>
 #include <string.h> ///< strcmp()
-#include <stdlib.h> ///< exit()
-
-#define NR_SUITES 3
-
-char *my_suites[NR_SUITES] = {"Basic", "Undefined", "Modern"};
 
 TEST(Basic, MathRelation)
 {
@@ -48,96 +43,23 @@ TEST(Modern, GreaterThanOrEqual)
 TEST(Modern, TestStr)
 {
   char *a = "my_string1";
-  char *b = "my_string";
+  char *b = "my_string1";
 
  ASSERT_STRCMP(a, b, IOPSENUM_MEQ);
 }
 
-void register_basic_tests()
+void load_suites()
 {
   REGISTER_TEST(Basic, MathRelation);
   REGISTER_TEST(Basic, Equality);
-}
 
-void register_modern_tests()
-{
   REGISTER_TEST(Modern, LessThanOrEqual);
   REGISTER_TEST(Modern, GreaterThanOrEqual);
   REGISTER_TEST(Modern, TestStr);
 }
 
-void *register_suite_tests[NR_SUITES] = {register_basic_tests, NULL, register_modern_tests};
-
-void load_suites()
-{
-  char j = 0;
-
-  while(j != NR_SUITES)
-  {
-    if(register_suite_tests[j] != NULL)
-    {
-      printf("Suite %s registered.\n", my_suites[j]);
-      ((void (*)())(register_suite_tests[j]))();
-    }
-    j++;
-  }
-}
-
-void print_usage()
-{
-  fprintf(stderr, "Usage: ./example [OPTION] [ARG]\n"
-      "supported suites: Basic, Modern\n"
-      "--help shows this description\n"
-      "--all runs all supported suites\n"
-      "--suite <suite_name> runs all the tests registered within the given suite_name\n");
-}
-
 int main(int argc, char **argv)
 {
-  char i, j = 0;
-
-  if(argc < 2)
-  {
-    fprintf(stderr, "Not enough arguments, check the usage below\n\n");
-    print_usage();
-    exit(EXIT_FAILURE);
-  }
-
-  for(i = 1; i < argc; i++)
-  {
-    if(!(strcmp(argv[i], "--all")))
-    {
-      load_suites();
-      break;
-    }
-    else if(!(strcmp(argv[i], "--suite")))
-    {
-      while(j != NR_SUITES)
-      {
-        if(!(strcmp(my_suites[j], argv[i + 1])))
-        {
-          printf("Suite %s registered.\n", my_suites[j]);
-          ((void (*)())(register_suite_tests[j]))();
-          j = 0; i++;
-          break;
-        }
-        j++;
-      }
-    }
-    else if(!(strcmp(argv[i], "--help")))
-    {
-      print_usage();
-      exit(EXIT_SUCCESS);
-    }
-    else
-    {
-      fprintf(stderr, "Unknown test/option '%s' specified. Use --help to see the valid options.\n\n", argv[i]);
-      exit(EXIT_FAILURE);
-    }
-
-  }
-
-  printf("\nRunning test suites.\n");
-  run_all_tests();
-  exit(EXIT_SUCCESS);
+  load_suites();
+  _ctest_main(argc, argv);
 }

--- a/include/ctest/ctest.h
+++ b/include/ctest/ctest.h
@@ -8,6 +8,13 @@
 
 #include "ctest/assertions.h"
 
+#define _STRINGIFY(s) #s
+#define STRINGIFY(s) _STRINGIFY(s)
+
+#ifndef SUITE
+#define SUITE __ALL__
+#endif
+
 #define MAX_ASSERTIONS_PER_TEST 128
 #define MAX_TEST_CASES 128
 
@@ -53,3 +60,5 @@ void __register_test(const char *suite, const char *name, test_fn fn);
   } while (0)
 
 int run_all_tests();
+
+int _ctest_main(int argc, char **argv);

--- a/src/ctest_main.c
+++ b/src/ctest_main.c
@@ -6,11 +6,17 @@
 
 #include <stdio.h>
 #include <unistd.h>
+#include <stdlib.h> ///< exit()
+#include <string.h> ///< strcmp()
 
 void __register_test(const char *suite, const char *name, test_fn fn)
 {
-  struct test_case __test_case = {suite, name, fn};
-  test_cases[tests_count++] = __test_case;
+  if((!(strcmp(suite, STRINGIFY(SUITE)))) || (!(strcmp(STRINGIFY(SUITE), "__ALL__"))))
+  {
+    struct test_case __test_case = {suite, name, fn};
+    test_cases[tests_count++] = __test_case;
+  }
+  return;
 }
 
 int run_all_tests()
@@ -45,4 +51,11 @@ int run_all_tests()
 
   printf("\nAll tests have been passed.\n");
   return ASSERT_SUCCESS;
+}
+
+int _ctest_main(int argc, char **argv)
+{
+  printf("\nRunning test suites.\n\n");
+  run_all_tests();
+  exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
#8 can be closed.
ctest is now a library that can be used in any unit testing project in a simple manner.
load_suites() modified in order to register all tests if there is no suite defined in the preprocessing stage.
Also, a specific suite could be registered by defining accordingly the MYSUITE variable from the Makefile.
In order to provide a proper example, the example.c has been updated .